### PR TITLE
fix(console): prevented detection on chosen dot font (.|..)

### DIFF
--- a/src/Console/Figlet.php
+++ b/src/Console/Figlet.php
@@ -10,7 +10,7 @@
 
 namespace AMWScan\Console;
 
-use DirectoryIterator;
+use FilesystemIterator;
 
 class Figlet
 {
@@ -102,7 +102,10 @@ class Figlet
     public function loadRandomFont()
     {
         $font = null;
-        $fonts = new DirectoryIterator(self::$pathFonts);
+        $fonts = new FilesystemIterator(
+            self::$pathFonts,
+            FilesystemIterator::SKIP_DOTS
+        );
         $i = mt_rand(0, iterator_count($fonts) - 1);
         $c = 0;
         foreach ($fonts as $file) {


### PR DESCRIPTION
fixes #40

### Before

Possible fonts:
```
stop.flf
colossal.flf
basic.flf
smkeyboard.flf
rozzo.flf
ansishadow.flf
..
.
```
Possible selected font: `/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/..`

### After

Possible fonts:
```
/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/stop.flf
/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/colossal.flf
/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/basic.flf
/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/smkeyboard.flf
/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/rozzo.flf
/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/ansishadow.flf
```
Possible selected font: `/XYZ/vendor/marcocesarato/amwscan/src/Console/Fonts/smkeyboard.flf`

No dot files could be selected.