### PR TITLE
Added a check for `phar.readonly`

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -27,6 +27,13 @@ if (file_exists($output . '.gz')) {
 if (file_exists($finalOutput)) {
     unlink($finalOutput);
 }
+
+// check that phar.readonly to off
+if (1 == ini_get('phar.readonly')) {
+    echo "Can't create a Phar file. Please set `phar.readonly = Off` in your php.ini\n";
+    exit(1);
+}
+
 // create phar
 $p = new Phar($output);
 


### PR DESCRIPTION
If `phar.readonly` in `php.ini` is set to On (by default) then the Phar couldn't be created. This change checks the setting and returns an error with a helpful message how to fix it.

phar-readonly