### PR TITLE
Make `scanner` executable

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -30,13 +30,26 @@ if (file_exists($finalOutput)) {
 // create phar
 $p = new Phar($output);
 
+// start buffering. Mandatory to modify stub.
+$p->startBuffering();
+
+// pointing main file which requires all classes
+$defaultStub = $p->createDefaultStub('index.php', '/index.php');
+
 // creating our library using whole directory
 $p->buildFromDirectory($input);
 
-// pointing main file which requires all classes
-$p->setDefaultStub('index.php', '/index.php');
+// Create a custom stub to add the shebang
+$stub = "#!/usr/bin/env php\n" . $defaultStub;
+
+// Add the stub
+$p->setStub($stub);
+
+$p->stopBuffering();
 
 unset($p);
 rename($output, $finalOutput);
+
+chmod($finalOutput, 0755);
 
 echo "$output successfully created";


### PR DESCRIPTION
Similar to how `composer` is an executable phar file build script is modified to produce an executable `scanner`.

Changes:

* Phar file is prepended with `#!/usr/bin/env php`
* Phar is made executable by setting `x` file attribute

It doesn't introduce any backward compatibility breaks as it's still possible to run it via `php scanner`