### PR TITLE
Add --ignore-exploits argument

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -53,12 +53,13 @@ Usage: amwscan [--lite|-a] [--help|-h|-?] [--log|-l <path>] [--backup|-b] [--off
         <offset>] [--limit <limit>] [--report|-r] [--report-format <format>]
         [--version|-v] [--update|-u] [--only-signatures|-s] [--only-exploits|-e]
         [--only-functions|-f] [--defs] [--defs-exploits] [--defs-functions]
-        [--defs-functions-enc] [--exploits <exploits>] [--functions <functions>]
-        [--whitelist-only-path] [--max-filesize <filesize>] [--silent]
-        [--ignore-paths|--ignore-path <paths>] [--filter-paths|--filter-path <paths>]
-        [--auto-clean] [--auto-clean-line] [--auto-delete] [--auto-quarantine]
-        [--auto-skip] [--auto-whitelist] [--auto-prompt <prompt>] [--path-whitelist
-        <path>] [--path-backups <path>] [--path-quarantine <path>] [--path-logs <path>]
+        [--defs-functions-enc] [--exploits <exploits>] [--ignore-exploits
+        <exploits>] [--functions <functions>] [--whitelist-only-path]
+        [--max-filesize <filesize>] [--silent] [--ignore-paths|--ignore-path
+        <paths>] [--filter-paths|--filter-path <paths>] [--auto-clean]
+        [--auto-clean-line] [--auto-delete] [--auto-quarantine] [--auto-skip]
+        [--auto-whitelist] [--auto-prompt <prompt>] [--path-whitelist <path>]
+        [--path-backups <path>] [--path-quarantine <path>] [--path-logs <path>]
         [--path-report <path>] [--disable-colors|--no-colors|--no-color]
         [--disable-cache|--no-cache] [--disable-report|--no-report]
         [--scan-all|--all] [<path>]

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -37,6 +37,7 @@ To open files with nano or vim run the scripts with **php -d disable_functions='
 --disable-colors|--no-colors|--no-color        - Disable CLI colors
 --disable-report|--no-report                   - Disable report generation
 --exploits <exploits>                          - Filter exploits
+--ignore-exploits <explots>                    - Ignore exploit/s, for multiple value separate with comma.
 --filter-paths|--filter-path <paths>           - Filter path/s, for multiple value separate with comma.
                                                  Wildcards are enabled ex. /path/*/htdocs or /path/*.php
 --functions <functions>                        - Define functions to search

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -437,6 +437,7 @@ class Scanner
         self::$argv->addFlag('defs-functions', ['default' => false, 'help' => 'Get default definitions functions lists']);
         self::$argv->addFlag('defs-functions-encoded', ['default' => false, 'help' => 'Get default definitions functions encoded lists']);
         self::$argv->addFlag('exploits', ['default' => false, 'has_value' => true, 'help' => 'Filter exploits']);
+        self::$argv->addFlag('ignore-exploits', ['default' => false, 'has_value' => true, 'help' => 'Ignore exploit/s, for multiple value separate with comma.']);
         self::$argv->addFlag('functions', ['default' => false, 'has_value' => true, 'help' => 'Define functions to search']);
         self::$argv->addFlag('whitelist-only-path', ['default' => false, 'help' => 'Check on whitelist only file path and not line number']);
         self::$argv->addFlag('max-filesize', ['default' => -1, 'has_value' => true, 'value_name' => 'filesize', 'help' => 'Set max filesize to scan']);
@@ -637,6 +638,27 @@ class Scanner
             if (!empty($filtered) && count($filtered) > 0) {
                 foreach (Exploits::getAll() as $key => $value) {
                     if (in_array($key, $filtered, true)) {
+                        $exploits[$key] = $value;
+                    }
+                }
+                if (!empty($exploits) && count($exploits) > 0) {
+                    CLI::writeLine('Exploit to search: ' . implode(', ', array_keys($exploits)));
+                } else {
+                    $exploits = [];
+                }
+            }
+            self::setExploits($exploits);
+        }
+
+        // Ignore exploits
+        if (isset(self::$argv['ignore-exploits']) && !empty(self::$argv['ignore-exploits'])) {
+            $exploits = [];
+            $ignored = str_replace(["\n", "\r", "\t", ' '], '', self::$argv['ignore-exploits']);
+            $ignored = @explode(',', $ignored);
+            $ignored = array_map('trim', $ignored);
+            if (!empty($ignored) && count($ignored) > 0) {
+                foreach (Exploits::getAll() as $key => $value) {
+                    if (! in_array($key, $ignored, true)) {
                         $exploits[$key] = $value;
                     }
                 }


### PR DESCRIPTION
When running this on WordPress plugins `non_printable` exploit gets lots of false positives but I'd like to turn off only that one.