### PR TITLE
Fix non_printable exploit rule

### DIFF
--- a/src/Exploits.php
+++ b/src/Exploits.php
@@ -185,7 +185,7 @@ class Exploits
         'non_printable' => [
             'description' => 'Non printable technique is usually used for the obfuscation of malicious code',
             'level' => CodeMatch::DANGEROUS,
-            'pattern' => '/(function|return|base64_decode).{,256}[^\\x00-\\x1F\\x7F-\\xFF]{3}/i',
+            'pattern' => '/(function|return|base64_decode).{,256}[\\x00-\\x1F\\x7F-\\xFF]{3}/ui',
         ],
         'double_var' => [
             'description' => 'Double var technique is usually used for the obfuscation of malicious code',


### PR DESCRIPTION
The detection pattern here seems to be incorrect, as every non printable character is excluded from the match, therefore including any printable char to the match.
This leads to a huge amount of false positives, like any function declaration `public function myFunc()`.

I also added the "u" flag in the regex, as PHP comments including non english characters (like french "é") would also raise a false positive.