### PR TITLE
Error on unknown commandline option, instead of silently ignoring e.g…

### DIFF
--- a/src/Console/Argv.php
+++ b/src/Console/Argv.php
@@ -108,7 +108,8 @@ class Argv implements \ArrayAccess
                     $value = $matches[2];
                 }
                 if (!$flag = @$this->flags[$arg]) {
-                    return;
+                    fwrite(STDERR, "Error: Unknown flag '{$arg}'\n");
+                    exit(1);
                 }
                 unset($args[$pos]);
                 if ($flag->hasValue) {


### PR DESCRIPTION
…. a typo