### PR TITLE
Do not auto add php-cs fixes to a commit.

### DIFF
--- a/bin/fix-cs
+++ b/bin/fix-cs
@@ -17,7 +17,9 @@ git diff --cached --name-only --diff-filter=ACMR HEAD -- '*.php' | while read li
   echo " - Fixing: ${line}"
   # PHP CS Fixer
   PHP_CS_FIXER_IGNORE_ENV=1 php "${CURRENT_DIRECTORY}/run" ${PHP_CS_FIXER} fix --config=${PHP_CS_CONFIG} --verbose ${line};
-  git add "$line";
+  git diff "$line";
+
+  echo "NOTE: consider adding these changes to the commit with git add --patch $line; git commit --amend"
 done
 
 # shellcheck disable=SC2164


### PR DESCRIPTION
I do not want to commit and sign changes that I've not seen.