### PR TITLE
suhosin signature gave false positives

### DIFF
--- a/src/Signatures.php
+++ b/src/Signatures.php
@@ -104,7 +104,6 @@ class Signatures
         'ps -aux',
         'rootkit',
         'slowloris',
-        'suhosin',
         'sun-tzu',
         'trojan',
         'uname -a',

--- a/tests/Fixtures/clean/wordpress_admin-nl_NL.l10n.php
+++ b/tests/Fixtures/clean/wordpress_admin-nl_NL.l10n.php
@@ -1,0 +1,4 @@
+<?
+
+// Exerpt from wp-content/languages/admin-nl_NL.l10n.php
+return return ['x-generator'=>'GlotPress/4.0.3','translation-revision-date'=>'2026-03-06 07:16:45+0000','plural-forms'=>'nplurals=2; plural=n != 1;','project-id-version'=>'WordPress - 6.9.x - Development - Administration','language'=>'nl','messages'=> ['Is SUHOSIN installed?'=>'Is SUHOSIN geïnstalleerd?']];

--- a/tests/Fixtures/clean/wordpress_admin-nl_NL.l10n.php
+++ b/tests/Fixtures/clean/wordpress_admin-nl_NL.l10n.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 // Exerpt from wp-content/languages/admin-nl_NL.l10n.php
-return return ['x-generator'=>'GlotPress/4.0.3','translation-revision-date'=>'2026-03-06 07:16:45+0000','plural-forms'=>'nplurals=2; plural=n != 1;','project-id-version'=>'WordPress - 6.9.x - Development - Administration','language'=>'nl','messages'=> ['Is SUHOSIN installed?'=>'Is SUHOSIN geïnstalleerd?']];
+return ['x-generator'=>'GlotPress/4.0.3','translation-revision-date'=>'2026-03-06 07:16:45+0000','plural-forms'=>'nplurals=2; plural=n != 1;','project-id-version'=>'WordPress - 6.9.x - Development - Administration','language'=>'nl','messages'=> ['Is SUHOSIN installed?'=>'Is SUHOSIN geïnstalleerd?']];


### PR DESCRIPTION
This gave a falsepositive when an en_US core is downloaded, but later another language is installed.

Can we remove the suhosin signature, or make it more specific to a malware usage?


Extracted from https://github.com/marcocesarato/PHP-Antimalware-Scanner/pull/139