### PR TITLE
Verify that rename actually removes the source file

### DIFF
--- a/src/Actions.php
+++ b/src/Actions.php
@@ -93,7 +93,20 @@ class Actions
         if (!is_dir(dirname($quarantine)) && (!mkdir($concurrentDirectory = dirname($quarantine), 0755, true) && !is_dir($concurrentDirectory))) {
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }
-        rename($file, $quarantine);
+        if (!rename($file, $quarantine)) {
+            return false;
+        }
+
+        // When source and destination are on different filesystems,
+        // rename() performs a copy then attempts to unlink the source.
+        // PHP returns true even if the source could not be removed,
+        // so we must verify that the original file is actually gone.
+        if (is_file($file)) {
+            self::unlink($file);
+            if (is_file($file)) {
+                return false;
+            }
+        }
 
         return $quarantine;
     }

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -1344,6 +1344,10 @@ class Scanner
                                 // Move to quarantine
                             case in_array($confirmation, ['2', 'quarantine']):
                                 $quarantine = Actions::moveToQuarantine($filePath);
+                                if ($quarantine === false) {
+                                    CLI::writeLine("File '$filePath' could not be moved to quarantine!", 2, 'red');
+                                    break;
+                                }
                                 self::$report['quarantine'][] = $quarantine;
                                 CLI::writeLine("File '$filePath' moved to quarantine!", 2, 'green');
                                 $inLoop = false;


### PR DESCRIPTION
I noticed malware that removed the write permission on it's own directory... 
The scanner silently fail to move the files there into quarantine.