### PR TITLE
Ensure the parent dir is writable for delete and quarantine actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Allow delete and quarantine actions to handle permission-locked directories without permanently changing surviving directory permissions.
 - Refined WordPress admin spacing, centered page loading states, report summaries, table containment and optional columns, scan widget actions, status cues, responsive modals, malware inspection, confirmation label behavior, and collapsible section consistency.
 
 <!-- BEGIN HEADER -->

--- a/src/Remediation/Actions.php
+++ b/src/Remediation/Actions.php
@@ -184,6 +184,9 @@ class Actions
      */
     protected static function renameFile($source, $destination)
     {
+        self::ensureParentWritable($source);
+        self::ensureParentWritable($destination);
+
         return rename($source, $destination);
     }
 
@@ -721,16 +724,51 @@ class Actions
 
             foreach ($files as $fileinfo) {
                 $action = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+                self::ensureParentWritable($fileinfo->getRealPath());
                 $action($fileinfo->getRealPath());
             }
+
+            self::ensureParentWritable($path);
 
             return rmdir($path);
         }
 
         if (file_exists($path)) {
+            self::ensureParentWritable($path);
+
             return unlink($path);
         }
 
         return false;
+    }
+
+    protected static function ensureWritable($path)
+    {
+        if (!is_file($path) && !is_dir($path)) {
+            return false;
+        }
+
+        $perms = @fileperms($path);
+        if ($perms === false) {
+            return false;
+        }
+
+        if (($perms & 0200) !== 0) {
+            return true;
+        }
+
+        $target = is_dir($path) ? ($perms | 0300) : ($perms | 0200);
+
+        return @chmod($path, $target);
+    }
+
+    protected static function ensureParentWritable($path)
+    {
+        $parent = dirname($path);
+        if ($parent === '' || $parent === '.' || $parent === DIRECTORY_SEPARATOR) {
+            return true;
+        }
+
+        return self::ensureWritable($parent);
     }
 }

--- a/src/Remediation/Actions.php
+++ b/src/Remediation/Actions.php
@@ -184,10 +184,11 @@ class Actions
      */
     protected static function renameFile($source, $destination)
     {
-        self::ensureParentWritable($source);
-        self::ensureParentWritable($destination);
-
-        return rename($source, $destination);
+        return self::withWritableParent($source, static function () use ($source, $destination) {
+            return self::withWritableParent($destination, static function () use ($source, $destination) {
+                return rename($source, $destination);
+            });
+        });
     }
 
     /**
@@ -717,58 +718,64 @@ class Actions
     protected static function unlink($path)
     {
         if (is_dir($path) && !is_link($path)) {
-            $files = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::CHILD_FIRST
-            );
+            return self::withTemporaryPermissions($path, 0700, static function () use ($path) {
+                $entries = @scandir($path);
+                if ($entries === false) {
+                    return false;
+                }
 
-            foreach ($files as $fileinfo) {
-                $action = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
-                self::ensureParentWritable($fileinfo->getRealPath());
-                $action($fileinfo->getRealPath());
-            }
+                foreach ($entries as $entry) {
+                    if ($entry === '.' || $entry === '..') {
+                        continue;
+                    }
+                    if (!self::unlink($path . DIRECTORY_SEPARATOR . $entry)) {
+                        return false;
+                    }
+                }
 
-            self::ensureParentWritable($path);
-
-            return rmdir($path);
+                return self::withWritableParent($path, static function () use ($path) {
+                    return rmdir($path);
+                });
+            });
         }
 
-        if (file_exists($path)) {
-            self::ensureParentWritable($path);
-
-            return unlink($path);
+        if (file_exists($path) || is_link($path)) {
+            return self::withWritableParent($path, static function () use ($path) {
+                return unlink($path);
+            });
         }
 
         return false;
     }
 
-    protected static function ensureWritable($path)
-    {
-        if (!is_file($path) && !is_dir($path)) {
-            return false;
-        }
-
-        $perms = @fileperms($path);
-        if ($perms === false) {
-            return false;
-        }
-
-        if (($perms & 0200) !== 0) {
-            return true;
-        }
-
-        $target = is_dir($path) ? ($perms | 0300) : ($perms | 0200);
-
-        return @chmod($path, $target);
-    }
-
-    protected static function ensureParentWritable($path)
+    protected static function withWritableParent($path, callable $action)
     {
         $parent = dirname($path);
         if ($parent === '' || $parent === '.' || $parent === DIRECTORY_SEPARATOR) {
-            return true;
+            return $action();
         }
 
-        return self::ensureWritable($parent);
+        return self::withTemporaryPermissions($parent, 0300, $action);
+    }
+
+    protected static function withTemporaryPermissions($path, $required, callable $action)
+    {
+        $permissions = @fileperms($path);
+        $original = $permissions === false ? null : $permissions & 07777;
+        $changed = $original !== null
+            && ($original & $required) !== $required
+            && @chmod($path, $original | $required);
+        if ($changed) {
+            clearstatcache(true, $path);
+        }
+
+        try {
+            return $action();
+        } finally {
+            if ($changed && file_exists($path)) {
+                @chmod($path, $original);
+                clearstatcache(true, $path);
+            }
+        }
     }
 }

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -66,6 +66,56 @@ class ActionsTest extends TestCase
         $this->assertSame('malware', file_get_contents($quarantine));
     }
 
+    public function testMoveToQuarantineTemporarilyMakesSourceParentWritable()
+    {
+        $this->requirePosixPermissions();
+        $source = $this->createMalwareFile();
+        $sourceDirectory = dirname($source);
+        Scanner::$pathScan = $sourceDirectory;
+        Scanner::$pathQuarantine = $this->temporaryDirectory . DIRECTORY_SEPARATOR . 'quarantine';
+        chmod($sourceDirectory, 0555);
+
+        try {
+            $quarantine = Actions::moveToQuarantine($source);
+
+            $this->assertNotFalse($quarantine);
+            $this->assertFileDoesNotExist($source);
+            $this->assertSame(0555, fileperms($sourceDirectory) & 0777);
+        } finally {
+            chmod($sourceDirectory, 0755);
+        }
+    }
+
+    public function testCleanQuarantineRemovesNonSearchableDirectories()
+    {
+        $this->requirePosixPermissions();
+        $quarantine = $this->temporaryDirectory . DIRECTORY_SEPARATOR . 'quarantine';
+        $nested = $quarantine . DIRECTORY_SEPARATOR . 'nested';
+        mkdir($nested, 0755, true);
+        file_put_contents($nested . DIRECTORY_SEPARATOR . 'malware.php', 'malware');
+        Scanner::$pathQuarantine = $quarantine;
+        chmod($nested, 0600);
+        chmod($quarantine, 0600);
+
+        $this->assertTrue(Actions::cleanQuarantine());
+        $this->assertDirectoryDoesNotExist($quarantine);
+    }
+
+    public function testParentPermissionsAreRestoredWhenAnActionFails()
+    {
+        $this->requirePosixPermissions();
+        $directory = $this->temporaryDirectory . DIRECTORY_SEPARATOR . 'locked';
+        $path = $directory . DIRECTORY_SEPARATOR . 'malware.php';
+        mkdir($directory, 0755);
+        file_put_contents($path, 'malware');
+        chmod($directory, 01666);
+
+        $this->assertFalse(PermissionActionStub::failWithWritableParent($path));
+        $this->assertSame(01666, fileperms($directory) & 07777);
+
+        chmod($directory, 0755);
+    }
+
     public function testRemediationServicesRemainAvailableAlongsideLegacyActions()
     {
         foreach ([
@@ -323,21 +373,46 @@ class ActionsTest extends TestCase
         return $source;
     }
 
+    private function requirePosixPermissions()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('POSIX permission behavior is not available on Windows.');
+        }
+    }
+
     private function removeDirectory($directory)
     {
         if (!is_dir($directory)) {
             return;
         }
 
-        $files = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST
-        );
-        foreach ($files as $file) {
-            $action = $file->isDir() ? 'rmdir' : 'unlink';
-            $action($file->getPathname());
+        @chmod($directory, 0700);
+        foreach (scandir($directory) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $directory . DIRECTORY_SEPARATOR . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDirectory($path);
+            } else {
+                @unlink($path);
+            }
         }
-        rmdir($directory);
+        @rmdir($directory);
+    }
+}
+
+class PermissionActionStub extends Actions
+{
+    public static function failWithWritableParent($path)
+    {
+        return parent::withWritableParent($path, static function () use ($path) {
+            if ((fileperms(dirname($path)) & 0300) !== 0300) {
+                throw new \RuntimeException('Parent directory was not writable and searchable.');
+            }
+
+            return false;
+        });
     }
 }
 


### PR DESCRIPTION
I noticed sites where malware had applied `chmod a-w` to it's files, which prevented this tool from cleanup up.