### PR TITLE
test: whitelist every parallel scan finding

### DIFF
--- a/tests/Integration/ParallelScanTest.php
+++ b/tests/Integration/ParallelScanTest.php
@@ -125,20 +125,20 @@ class ParallelScanTest extends CLITestCase
         $baseline = json_decode(file_get_contents($baselinePath), true);
         $flaggedPath = $this->parallelPath . '/nested/flagged.php';
         $patterns = $baseline['infectedFound'][$flaggedPath];
-        $pattern = reset($patterns);
-        $entry = [
-            'file' => 'nested/flagged.php',
-            'exploit' => $pattern['key'],
-        ];
-        foreach (['line', 'match'] as $field) {
-            if (array_key_exists($field, $pattern)) {
-                $entry[$field] = $pattern[$field];
+        $whitelist = [];
+        foreach ($patterns as $key => $pattern) {
+            $entry = [
+                'file' => 'nested/flagged.php',
+                'exploit' => $pattern['key'],
+            ];
+            foreach (['line', 'match'] as $field) {
+                if (array_key_exists($field, $pattern)) {
+                    $entry[$field] = $pattern[$field];
+                }
             }
+            $whitelist[md5('parallel-whitelist-' . $key)] = $entry;
         }
-        file_put_contents($whitelistPath, json_encode([
-            md5('parallel-whitelist-1') => $entry,
-            md5('parallel-whitelist-2') => $entry,
-        ]));
+        file_put_contents($whitelistPath, json_encode($whitelist));
 
         $this->runScanner($this->parallelPath, [
             '--report-only',


### PR DESCRIPTION
Keep the root-relative whitelist regression deterministic when a fixture matches multiple detection patterns.