### PR TITLE
perf: skip duplicate content variants in exploit and signature scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+### Changed
+
+- Reduce duplicate signature and exploit checks when scan content variants are identical.
+
 <!-- BEGIN HEADER -->
 # Changelog
 

--- a/src/Scan/Scanner.php
+++ b/src/Scan/Scanner.php
@@ -1348,6 +1348,12 @@ class Scanner
             'decoded' => $contentDecoded, // Decoded content
         ];
 
+        // For clean files the cleaned, deobfuscated and decoded variants are
+        // usually identical, so scanning each duplicate repeats the same regex
+        // work. Matches only depend on the scanned bytes, so duplicates can be
+        // dropped for the exploit and signature passes.
+        $scanContents = array_unique($contents);
+
         $contentHashSource = str_replace(["\r\n", "\r"], "\n", $contentRaw);
         $sha256 = hash('sha256', $contentHashSource);
         $builtInHash = Signatures::findKnownMalwareHash('sha256', $sha256);
@@ -1429,7 +1435,7 @@ class Scanner
                     }
                 };
                 // Check exploits
-                foreach ($contents as $contentType => $content) {
+                foreach ($scanContents as $contentType => $content) {
                     if (@preg_match_all($pattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
                         $lineNumbers = $contentType === 'raw'
                             ? CodeMatch::getLineNumbers(array_column($matches[0], 1), $contentRaw)
@@ -1507,7 +1513,7 @@ class Scanner
                     }
                 };
                 // Check definitions
-                foreach ($contents as $contentType => $content) {
+                foreach ($scanContents as $contentType => $content) {
                     if (@preg_match_all($regexPattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
                         $lineNumbers = $contentType === 'raw'
                             ? CodeMatch::getLineNumbers(array_column($matches[0], 1), $contentRaw)


### PR DESCRIPTION
## Summary

For clean files the `cleaned`, `deobfuscated` and `decoded` content variants are usually identical, so the exploit and signature passes scan the same bytes two or three times. This PR deduplicates the content variants (`array_unique`) and scans each unique variant once, cutting the number of regex passes per file.

The `raw` variant (and its offset-based line numbers) is always kept, and the function pass still scans every variant because it classifies matches by content type.

## Safety verification

I compared report output on the repository's own malware fixtures (`test-files` + `tests/Fixtures/patterns`, `modes`, `findings`, including the comment-obfuscated `malware_sample_2308ba68.php` sample):

- checked out `master` and this branch in separate worktrees, each scanned with its own `bin/amwscan`;
- ran report-only JSON scans in `-s` (signatures), `-e` (exploits) and `-f` (functions+signatures) modes with `--scan-all`;
- normalized the JSON reports (dropped ids/timestamps, aligned paths) and compared:

```
mode -s: IDENTICAL
mode -e: IDENTICAL
mode -f: IDENTICAL
```

No detections are lost or added: `detected`, `scanned`, the set of infected files and every finding match exactly.

Why this holds in general: `array_unique` removes only byte-identical variants, and a regex match depends only on the scanned bytes, so a duplicate variant would have produced the same result. Keys are preserved (the `raw` fast path for line numbers is unaffected), and the function pass is not modified.
