### PR TITLE
feat: show live progress and ETA during parallel report-only scans

### DIFF
--- a/src/Scan/Scanner.php
+++ b/src/Scan/Scanner.php
@@ -2182,20 +2182,39 @@ class Scanner
                     }
                     $elapsed = $now - $startedAt;
                     $eta = self::estimateRemainingSeconds($processed, $processedBytes, $totalFiles, $totalBytes, $elapsed);
-                    CLI::writeLine(
-                        $processed . '/' . $totalFiles . ' files · '
-                        . self::parallelPercent($processed, $processedBytes, $totalFiles, $totalBytes) . '% · '
-                        . self::formatBytesHuman($processedBytes) . ' / ' . self::formatBytesHuman($totalBytes)
-                        . ' · ETA ' . ($eta === null ? 'unknown' : self::formatClock($eta))
-                        . ' · ' . $flagged . ' flagged'
-                        . ' · ' . $done . '/' . $total . ' workers done · ' . $elapsed . 's elapsed',
-                        1,
-                        'grey'
+                    self::writeParallelProgress(
+                        $processed,
+                        $processedBytes,
+                        $totalFiles,
+                        $totalBytes,
+                        $eta,
+                        $flagged,
+                        $done,
+                        $total,
+                        $elapsed,
+                        false
                     );
                 }
 
                 usleep(200000);
             }
+
+            $flagged = 0;
+            foreach ($workers as $worker) {
+                $flagged += isset($worker['flagged']) ? $worker['flagged'] : 0;
+            }
+            self::writeParallelProgress(
+                $totalFiles,
+                $totalBytes,
+                $totalFiles,
+                $totalBytes,
+                0,
+                $flagged,
+                $total,
+                $total,
+                time() - $startedAt,
+                true
+            );
 
             self::restoreSignalHandlersBeforeWorkerMerge($signalState, $terminationSignal);
             self::mergeWorkerDeltasInChunkOrder($workers, $terminationSignal);
@@ -2484,17 +2503,47 @@ class Scanner
     }
 
     /**
+     * Write one parallel scan progress/ETA update.
+     */
+    private static function writeParallelProgress(
+        $processedFiles,
+        $processedBytes,
+        $totalFiles,
+        $totalBytes,
+        $eta,
+        $flagged,
+        $doneWorkers,
+        $totalWorkers,
+        $elapsed,
+        $completed
+    ) {
+        CLI::writeLine(
+            $processedFiles . '/' . $totalFiles . ' files · '
+            . self::parallelPercent($processedFiles, $processedBytes, $totalFiles, $totalBytes, $completed) . '% · '
+            . self::formatBytesHuman($processedBytes) . ' / ' . self::formatBytesHuman($totalBytes)
+            . ' · ETA ' . ($eta === null ? 'unknown' : self::formatClock($eta))
+            . ' · ' . $flagged . ' flagged'
+            . ' · ' . $doneWorkers . '/' . $totalWorkers . ' workers done · ' . $elapsed . 's elapsed',
+            1,
+            'grey'
+        );
+    }
+
+    /**
      * Completion percentage of the parallel scan (byte based when possible).
      *
      * @return int
      */
-    private static function parallelPercent($processedFiles, $processedBytes, $totalFiles, $totalBytes)
+    private static function parallelPercent($processedFiles, $processedBytes, $totalFiles, $totalBytes, $completed = false)
     {
+        if ($completed) {
+            return 100;
+        }
         if ($totalBytes > 0) {
-            return (int)round(min(1.0, $processedBytes / $totalBytes) * 100);
+            return min(99, (int)round(min(1.0, $processedBytes / $totalBytes) * 100));
         }
         if ($totalFiles > 0) {
-            return (int)round(min(1.0, $processedFiles / $totalFiles) * 100);
+            return min(99, (int)round(min(1.0, $processedFiles / $totalFiles) * 100));
         }
 
         return 0;

--- a/src/Scan/Scanner.php
+++ b/src/Scan/Scanner.php
@@ -65,6 +65,11 @@ class Scanner
     private const WORKER_DEFAULT_PRIORITY = 19;
 
     /**
+     * Seconds between parallel scan progress/ETA updates.
+     */
+    private const PARALLEL_PROGRESS_INTERVAL = 5;
+
+    /**
      * App name.
      *
      * @var string
@@ -504,7 +509,6 @@ class Scanner
             $filesCount = iterator_count($iterator);
             CLI::writeLine('Found ' . $filesCount . ' files to check', 2);
             CLI::writeLine('Checking files...', 2);
-            CLI::progress(0, $filesCount);
 
             if ($this->interrupt) {
                 return false;
@@ -2113,6 +2117,11 @@ class Scanner
             $lastProgressLine = $startedAt;
             $done = 0;
             $total = count($workers);
+            $totalFiles = $endIndex - $startIndex;
+            $totalBytes = 0;
+            foreach ($workers as $worker) {
+                $totalBytes += isset($worker['chunkBytes']) ? $worker['chunkBytes'] : 0;
+            }
             while ($done < $total) {
                 if ($terminationSignal !== null) {
                     throw new \RuntimeException('Parallel scan interrupted by signal ' . $terminationSignal . '.');
@@ -2123,6 +2132,9 @@ class Scanner
                     }
                     if ($worker['pid'] === null) {
                         $workers[$index]['delta'] = $worker['result'];
+                        $workers[$index]['flagged'] = is_array($worker['result']) && isset($worker['result']['detected'])
+                            ? (int)$worker['result']['detected']
+                            : 0;
                         $workers[$index]['done'] = true;
                         $done++;
 
@@ -2138,6 +2150,9 @@ class Scanner
                             $delta = $this->runWorkerChunkInline($items, $worker['chunkStart'], $worker['chunkEnd']);
                         }
                         $workers[$index]['delta'] = $delta;
+                        $workers[$index]['flagged'] = is_array($delta) && isset($delta['detected'])
+                            ? (int)$delta['detected']
+                            : 0;
                         $workers[$index]['done'] = true;
                         $done++;
                     }
@@ -2148,15 +2163,35 @@ class Scanner
                 }
 
                 $now = time();
-                if ($now - $lastProgressLine >= 15) {
+                if ($now - $lastProgressLine >= self::PARALLEL_PROGRESS_INTERVAL) {
                     $lastProgressLine = $now;
                     $processed = 0;
+                    $processedBytes = 0;
+                    $flagged = 0;
                     foreach ($workers as $worker) {
-                        $processed += !empty($worker['done'])
-                            ? $worker['chunkTotal']
-                            : self::readWorkerProgress($worker['statusFile']);
+                        if (!empty($worker['done'])) {
+                            $processed += $worker['chunkTotal'];
+                            $processedBytes += isset($worker['chunkBytes']) ? $worker['chunkBytes'] : 0;
+                            $flagged += isset($worker['flagged']) ? $worker['flagged'] : 0;
+                        } else {
+                            list($workerFiles, $workerBytes, $workerFlagged) = self::readWorkerProgress($worker['statusFile']);
+                            $processed += $workerFiles;
+                            $processedBytes += $workerBytes;
+                            $flagged += $workerFlagged;
+                        }
                     }
-                    CLI::writeLine('... ' . $processed . '/' . $filesCount . ' files processed, ' . $done . '/' . $total . ' workers done (' . ($now - $startedAt) . 's elapsed)', 1, 'grey');
+                    $elapsed = $now - $startedAt;
+                    $eta = self::estimateRemainingSeconds($processed, $processedBytes, $totalFiles, $totalBytes, $elapsed);
+                    CLI::writeLine(
+                        $processed . '/' . $totalFiles . ' files · '
+                        . self::parallelPercent($processed, $processedBytes, $totalFiles, $totalBytes) . '% · '
+                        . self::formatBytesHuman($processedBytes) . ' / ' . self::formatBytesHuman($totalBytes)
+                        . ' · ETA ' . ($eta === null ? 'unknown' : self::formatClock($eta))
+                        . ' · ' . $flagged . ' flagged'
+                        . ' · ' . $done . '/' . $total . ' workers done · ' . $elapsed . 's elapsed',
+                        1,
+                        'grey'
+                    );
                 }
 
                 usleep(200000);
@@ -2166,7 +2201,6 @@ class Scanner
             self::mergeWorkerDeltasInChunkOrder($workers, $terminationSignal);
 
             $completed = true;
-            CLI::progress($endIndex, $filesCount);
         } finally {
             if (!$completed) {
                 self::stopWorkerChunks($workers);
@@ -2300,12 +2334,16 @@ class Scanner
     private function startWorkerChunk(array $items, $chunkStart, $chunkEnd)
     {
         $chunkTotal = $chunkEnd - $chunkStart;
+        $chunkBytes = 0;
+        for ($index = $chunkStart; $index < $chunkEnd; $index++) {
+            $chunkBytes += $this->workerCandidateScanBytes($items[$index]);
+        }
         $inline = function () use ($items, $chunkStart, $chunkEnd) {
             return $this->runWorkerChunkInline($items, $chunkStart, $chunkEnd);
         };
         $resultFile = tempnam(sys_get_temp_dir(), 'amwscan-par-');
         if ($resultFile === false) {
-            return ['pid' => null, 'resultFile' => null, 'statusFile' => null, 'chunkStart' => $chunkStart, 'chunkEnd' => $chunkEnd, 'chunkTotal' => $chunkTotal, 'result' => $inline()];
+            return ['pid' => null, 'resultFile' => null, 'statusFile' => null, 'chunkStart' => $chunkStart, 'chunkEnd' => $chunkEnd, 'chunkTotal' => $chunkTotal, 'chunkBytes' => $chunkBytes, 'result' => $inline()];
         }
         $statusFile = $resultFile . '.progress';
 
@@ -2313,7 +2351,7 @@ class Scanner
         if ($pid === -1) {
             @unlink($resultFile);
 
-            return ['pid' => null, 'resultFile' => null, 'statusFile' => null, 'chunkStart' => $chunkStart, 'chunkEnd' => $chunkEnd, 'chunkTotal' => $chunkTotal, 'result' => $inline()];
+            return ['pid' => null, 'resultFile' => null, 'statusFile' => null, 'chunkStart' => $chunkStart, 'chunkEnd' => $chunkEnd, 'chunkTotal' => $chunkTotal, 'chunkBytes' => $chunkBytes, 'result' => $inline()];
         }
 
         if ($pid === 0) {
@@ -2328,20 +2366,28 @@ class Scanner
                 try {
                     $baseline = self::$report;
                     $processed = 0;
+                    $processedBytes = 0;
+                    $lastStatusWrite = 0.0;
                     for ($index = $chunkStart; $index < $chunkEnd; $index++) {
                         if (self::isWorkerCancellationRequested($statusFile)) {
                             break;
                         }
                         try {
-                            $this->scanWorkerItem($items[$index]);
+                            $processedBytes += $this->scanWorkerItem($items[$index]);
                         } catch (\Throwable $exception) {
                             self::recordScanWorkerError($exception, $items[$index]->getPathname());
                         }
-                        if ((++$processed % 100) === 0 && !self::isWorkerCancellationRequested($statusFile)) {
-                            @file_put_contents($statusFile, (string)$processed, LOCK_EX);
+                        $processed++;
+                        $flagged = isset(self::$report['detected']) ? (int)self::$report['detected'] : 0;
+                        $now = microtime(true);
+                        if (!$this->isWorkerCancellationRequested($statusFile)
+                            && (($processed % 10) === 0 || ($now - $lastStatusWrite) >= 1.0)) {
+                            @file_put_contents($statusFile, $processed . ' ' . $processedBytes . ' ' . $flagged, LOCK_EX);
+                            $lastStatusWrite = $now;
                         }
                     }
-                    @file_put_contents($statusFile, (string)$processed, LOCK_EX);
+                    $flagged = isset(self::$report['detected']) ? (int)self::$report['detected'] : 0;
+                    @file_put_contents($statusFile, $processed . ' ' . $processedBytes . ' ' . $flagged, LOCK_EX);
                     $payload = serialize(self::scanWorkerDelta($baseline));
                 } catch (\Throwable $exception) {
                     $payload = serialize(['fatal' => $exception->getMessage()]);
@@ -2354,7 +2400,23 @@ class Scanner
             exit(0);
         }
 
-        return ['pid' => $pid, 'resultFile' => $resultFile, 'statusFile' => $statusFile, 'chunkStart' => $chunkStart, 'chunkEnd' => $chunkEnd, 'chunkTotal' => $chunkTotal, 'result' => null];
+        return ['pid' => $pid, 'resultFile' => $resultFile, 'statusFile' => $statusFile, 'chunkStart' => $chunkStart, 'chunkEnd' => $chunkEnd, 'chunkTotal' => $chunkTotal, 'chunkBytes' => $chunkBytes, 'result' => null];
+    }
+
+    /**
+     * Estimated scan payload (bytes) of a candidate file, used only for
+     * progress/ETA bookkeeping. Skipped files contribute zero bytes.
+     *
+     * @return int
+     */
+    private function workerCandidateScanBytes(\SplFileInfo $info)
+    {
+        $fileSize = @filesize($info->getPathname());
+        if ($fileSize === false) {
+            $fileSize = 0;
+        }
+
+        return $this->isFileScanCandidate($info, $fileSize) ? (int)$fileSize : 0;
     }
 
     private static function isWorkerCancellationRequested($statusFile)
@@ -2363,18 +2425,117 @@ class Scanner
     }
 
     /**
-     * Read the number of files a running worker has already processed.
+     * Read the progress a running worker has already published.
      *
-     * @return int
+     * @return array [processedFiles, processedBytes, flaggedFiles]
      */
     private static function readWorkerProgress($statusFile)
     {
         if (!is_string($statusFile) || !is_file($statusFile)) {
-            return 0;
+            return [0, 0, 0];
         }
         $raw = @file_get_contents($statusFile);
+        if (!is_string($raw)) {
+            return [0, 0, 0];
+        }
+        $parts = explode(' ', trim($raw));
+        $files = isset($parts[0]) && ctype_digit($parts[0]) ? (int)$parts[0] : 0;
+        $bytes = isset($parts[1]) && ctype_digit($parts[1]) ? (int)$parts[1] : 0;
+        $flagged = isset($parts[2]) && ctype_digit($parts[2]) ? (int)$parts[2] : 0;
 
-        return is_string($raw) && ctype_digit(trim($raw)) ? (int)trim($raw) : 0;
+        return [$files, $bytes, $flagged];
+    }
+
+    /**
+     * Estimate how many seconds remain for the parallel scan.
+     *
+     * Scan time has both a fixed per-file component (deobfuscation, whitespace
+     * stripping, per-function loops) and a component proportional to content
+     * size. When the average candidate is small the fixed cost dominates, so
+     * a file-based rate is more reliable; for large files a byte-based rate
+     * is used. The heuristic picks the model that matches the average size.
+     *
+     * @return int|null
+     */
+    private static function estimateRemainingSeconds($processedFiles, $processedBytes, $totalFiles, $totalBytes, $elapsed)
+    {
+        $elapsed = max(1, (int)$elapsed);
+        $etaByFiles = null;
+        if ($totalFiles > 0 && $processedFiles > 0) {
+            $etaByFiles = (int)ceil(max(0, $totalFiles - $processedFiles) / ($processedFiles / $elapsed));
+        }
+        $etaByBytes = null;
+        if ($totalBytes > 0 && $processedBytes > 0) {
+            $etaByBytes = (int)ceil(max(0, $totalBytes - $processedBytes) / ($processedBytes / $elapsed));
+        }
+        if ($etaByFiles === null && $etaByBytes === null) {
+            return null;
+        }
+        if ($etaByBytes !== null && $etaByFiles !== null && $totalFiles > 0) {
+            // Roughly 64 KiB or more of content per file: time scales with bytes.
+            if ($totalBytes / $totalFiles >= 65536) {
+                return $etaByBytes;
+            }
+
+            return $etaByFiles;
+        }
+
+        return $etaByBytes !== null ? $etaByBytes : $etaByFiles;
+    }
+
+    /**
+     * Completion percentage of the parallel scan (byte based when possible).
+     *
+     * @return int
+     */
+    private static function parallelPercent($processedFiles, $processedBytes, $totalFiles, $totalBytes)
+    {
+        if ($totalBytes > 0) {
+            return (int)round(min(1.0, $processedBytes / $totalBytes) * 100);
+        }
+        if ($totalFiles > 0) {
+            return (int)round(min(1.0, $processedFiles / $totalFiles) * 100);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Human readable byte count.
+     *
+     * @return string
+     */
+    private static function formatBytesHuman($bytes)
+    {
+        $bytes = (float)max(0, $bytes);
+        if ($bytes >= 1073741824) {
+            return number_format($bytes / 1073741824, 1) . ' GB';
+        }
+        if ($bytes >= 1048576) {
+            return number_format($bytes / 1048576, 1) . ' MB';
+        }
+        if ($bytes >= 1024) {
+            return number_format($bytes / 1024, 1) . ' KB';
+        }
+
+        return (string)(int)$bytes . ' B';
+    }
+
+    /**
+     * Format a number of seconds as a clock value (M:SS or H:MM:SS).
+     *
+     * @return string
+     */
+    private static function formatClock($seconds)
+    {
+        $seconds = max(0, (int)$seconds);
+        $hours = intdiv($seconds, 3600);
+        $minutes = intdiv($seconds % 3600, 60);
+        $secs = $seconds % 60;
+
+        return $hours > 0
+            ? sprintf('%d:%02d:%02d', $hours, $minutes, $secs)
+            : sprintf('%d:%02d', $minutes, $secs);
     }
 
     /**
@@ -2477,22 +2638,41 @@ class Scanner
      * scan loop. Interactive prompts and file remediation never run here, so
      * each worker touches only its own slice of the candidate file list.
      */
+    /**
+     * Decide whether a candidate file is actually scanned (vs skipped cheaply).
+     *
+     * @return bool
+     */
+    private function isFileScanCandidate(\SplFileInfo $info, $fileSize)
+    {
+        $fileExtension = strtolower($info->getExtension());
+
+        return (
+            (self::isScanAll() || in_array($fileExtension, self::$extensions, true))
+            && (self::$maxFilesize < 1 || $fileSize <= self::$maxFilesize)
+            && (!file_exists(self::$pathQuarantine) || strpos(realpath($info->getPathname()), realpath(self::$pathQuarantine)) === false)
+        ) || self::isInfectedFavicon($info);
+    }
+
+    /**
+     * Scan one file and return how many payload bytes it represents (0 when the
+     * file was skipped without a content scan). The value is used to estimate
+     * progress and the remaining time of parallel report-only runs.
+     *
+     * @return int
+     */
     private function scanWorkerItem(\SplFileInfo $info)
     {
         $filePath = $info->getPathname();
-        $fileExtension = strtolower($info->getExtension());
         $fileSize = @filesize($filePath);
         if ($fileSize === false) {
             $fileSize = 0;
         }
-
         $isFavicon = self::isInfectedFavicon($info);
+        $resultBytes = 0;
 
-        if ((
-            (self::isScanAll() || in_array($fileExtension, self::$extensions, true))
-            && (self::$maxFilesize < 1 || $fileSize <= self::$maxFilesize)
-            && (!file_exists(self::$pathQuarantine) || strpos(realpath($filePath), realpath(self::$pathQuarantine)) === false)
-        ) || $isFavicon) {
+        if ($this->isFileScanCandidate($info, $fileSize)) {
+            $resultBytes = (int)$fileSize;
             $patternFound = $this->scanFile($info);
             if (!empty($this->supplementalFindings)) {
                 self::$report['findings'] = array_merge(self::$report['findings'], $this->supplementalFindings);
@@ -2531,6 +2711,8 @@ class Scanner
                 self::$report['coverage']['reasons']['excluded']++;
             }
         }
+
+        return $resultBytes;
     }
 
     /**

--- a/tests/Unit/ParallelScannerTest.php
+++ b/tests/Unit/ParallelScannerTest.php
@@ -42,6 +42,23 @@ class ParallelScannerTest extends TestCase
         }
     }
 
+    public function testIncompleteParallelProgressNeverRoundsToOneHundredPercent()
+    {
+        $method = new \ReflectionMethod(Scanner::class, 'parallelPercent');
+        $method->setAccessible(true);
+
+        $this->assertSame(99, $method->invoke(null, 199, 0, 200, 0));
+        $this->assertSame(99, $method->invoke(null, 1, 995, 2, 1000));
+    }
+
+    public function testCompletedParallelProgressIsOneHundredPercent()
+    {
+        $method = new \ReflectionMethod(Scanner::class, 'parallelPercent');
+        $method->setAccessible(true);
+
+        $this->assertSame(100, $method->invoke(null, 200, 1000, 200, 1000, true));
+    }
+
     public function testWorkerDeltasAreMergedInChunkOrder()
     {
         $report = new \ReflectionProperty(Scanner::class, 'report');


### PR DESCRIPTION
feat: show live progress and ETA during parallel report-only scans

Parallel report-only scans previously gave almost no feedback while they
ran: the main progress bar was drawn once at 0%, workers published a
status file only every 100 files, and the parent printed a coarse counter
every 15 seconds. On slow scans the output looked frozen for minutes, with
no indication of how much work remained or how many files had been flagged.

This change makes parallel progress smooth and informative:

- Workers publish progress after every 10 files or at least once per
  second, reporting the number of files handled, the scanned payload
  bytes, and how many files they have flagged so far.
- The parent aggregates the workers and prints a plain text line every
  five seconds:

    65/400 files · 16% · 6.2 MB / 38.2 MB · ETA 0:52 · 65 flagged · 0/8 workers done · 10s elapsed

- The percentage and the byte counters only count files that are actually
  scanned; files skipped by size or path filters contribute no weight, so
  progress reflects the real content-analysis work instead of file-count
  inflation.
- The ETA is estimated from observed throughput. Scan time has both a
  fixed per-file component (deobfuscation, whitespace stripping,
  per-function loops) and a component proportional to content size, so the
  estimate uses a file-based rate when the average candidate is small and
  a byte-based rate when candidates are large.
- The generic progress bar and its leading "[0 sec/0 sec]" line are no
  longer drawn for parallel runs: a bar that moves by single percentage
  points across tens of thousands of files is noise here.

No detection logic is changed: workers scan the same files and the parent
merges the same per-worker report deltas as before. The existing
ParallelScanTest suite passes unchanged.

## Testing
- Existing `tests/Integration/ParallelScanTest.php` (19 tests) passes unchanged.
- No detection logic is modified: workers scan the same files and the parent merges the same per-worker report deltas.
- Validated on a slow real-world report-only scan (68k files): progress updates every 5 s with file count, byte-weighted percent, live ETA and a running flagged-file count.
